### PR TITLE
Filter empty or null values from code

### DIFF
--- a/RockMigrations.module.php
+++ b/RockMigrations.module.php
@@ -1128,7 +1128,8 @@ class RockMigrations extends WireData implements Module, ConfigurableModule {
       unset($data['name']);
       unset($data['rockmigrations']);
     }
-    $code = $this->varexport($data);
+    $code = array_filter($data, fn($value) => !is_null($value) && $value !== ''); // filter empty or null values
+    $code = $this->varexport($code);
     return "'{$item->name}' => $code,";
   }
 


### PR DESCRIPTION
So the migration code would be smaller as unnessesary values don't get copied.
The intention of this fix was to reduce the amount of code so no default or empty values are copied.
It would be great if the buildExport method of ProcessWire would provide an option that it only exports settings that are not default. Maybe we should create a request for this?