### PR TITLE
Support Repeater fields

### DIFF
--- a/.vscode/RockMigrations.code-snippets
+++ b/.vscode/RockMigrations.code-snippets
@@ -216,6 +216,33 @@
     ],
     "description": "Add a options field via RockMigrations"
   },
+  "rmf-repeater": {
+    "prefix": "rmf-repeater",
+    "body": [
+      "$1 => [",
+      "  'label' => 'Repeater Label',",
+      "  'type' => 'FieldtypeRepeater',",
+      "  'repeaterFields' => [",
+      "    0 => 'title',",
+      "    1 => 'text',",
+      "    2 => 'rte',",
+      "  ],",
+      "  'repeaterTitle' => '#n: {title}',",
+      "  'familyFriendly' => 1,",
+      "  'repeaterDepth' => 0,",
+      "  'tags' => '',",
+      "  'repeaterAddLabel' => 'Add New Item',",
+      "  'columnWidth' => 100,",
+      "  'fieldContexts' => [",
+      "    'title' => [",
+      "      'label' => 'My Label',",
+      "      'required' => 0,",
+      "    ],",
+      "  ],",
+      "],"
+    ],
+    "description": "Add a repeater field via RockMigrations"
+  },
 
   // Place your workspace snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and
   // description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope

--- a/RockMigrations.module.php
+++ b/RockMigrations.module.php
@@ -624,7 +624,7 @@ class RockMigrations extends WireData implements Module, ConfigurableModule
    *
    * Usage:
    * $rm->createField('myfield');
-   * 
+   *
    * $rm->createField('myfield', 'text', [
    *   'label' => 'My great field',
    * ]);
@@ -684,7 +684,7 @@ class RockMigrations extends WireData implements Module, ConfigurableModule
 
   /**
    * Create fields from array
-   * 
+   *
    * Usage:
    * $rm->createFields([
    *   'field1' => [...],
@@ -820,7 +820,7 @@ class RockMigrations extends WireData implements Module, ConfigurableModule
 
   /**
    * Create a new ProcessWire Template
-   * 
+   *
    * Usage:
    * $rm->createTemplate('foo', [
    *   'fields' => ['foo', 'bar'],
@@ -2371,33 +2371,37 @@ class RockMigrations extends WireData implements Module, ConfigurableModule
       }
 
       // support repeater field array
-      $contexts = [];
       if ($key === "repeaterFields") {
         $fields = $data[$key];
         $addFields = [];
         $index = 0;
         foreach ($fields as $i => $_field) {
-          if (is_string($i)) {
-            // we've got a field with field context info here
-            $fieldname = $i;
-            $fielddata = $_field;
-            $contexts[] = [
-              $fieldname,
-              $fielddata,
-              $this->getRepeaterTemplate($field),
-            ];
-          } else {
-            // field without field context info
-            $fieldname = $_field;
-          }
+          // field without field context info
+          $fieldname = $_field;
           $addFields[$index] = $this->fields->get((string)$fieldname)->id;
           $index++;
         }
         $data[$key] = $addFields;
 
         // add fields to repeater template
-        if ($tpl = $this->getRepeaterTemplate($field)) {
+        if ($tpl = $field->type->getRepeaterTemplate($field)) {
           $this->addFieldsToTemplate($addFields, $tpl);
+        }
+      }
+
+      // support repeater field contexts
+      if ($key === "fieldContexts") {
+        $contexts = [];
+        $fields = $data[$key];
+        foreach ($fields as $i => $_field) {
+          // we've got a field with field context info here
+          $fieldname = $i;
+          $fielddata = $_field;
+          $contexts[] = [
+            $fieldname,
+            $fielddata,
+            $field->type->getRepeaterTemplate($field),
+          ];
         }
 
         // set field contexts now that the fields are present
@@ -2405,6 +2409,7 @@ class RockMigrations extends WireData implements Module, ConfigurableModule
           $this->setFieldData($c[0], $c[1], $c[2]);
         }
       }
+
 
       // add support for setting options of a select field
       // this will remove non-existing options from the field!


### PR DESCRIPTION
2 fixes:
1. fields were not added to repeater templates because $this has no method getRepeaterTemplate(). It needs to be $field->type->getRepeaterTemplate(). Otherwise it woud throw an error. 
2. field contexts were not set because they are defined in a separate field property "fieldContexts" and not inside "repeaterFields". The logic was adjusted to fix this.

VSCode snippet rmf-repeater added for convenience.