### PR TITLE
make sure created permissions have a title

### DIFF
--- a/RockMigrations.module.php
+++ b/RockMigrations.module.php
@@ -796,6 +796,7 @@ class RockMigrations extends WireData implements Module, ConfigurableModule
       $perm = $this->wire->permissions->add($name);
       $this->log("Created permission $name");
     }
+    if(is_null($description)) $description = $name;
     $perm->setAndSave('title', $description);
     return $perm;
   }


### PR DESCRIPTION
Title field is mandatory when adding custom permissions through GUI.
If description parameter is not passed to createPermissions, we use the name as title.

Missing title can lead to strange behaviour. Example:
when adding and then removing a permission 'foo' with empty title via RockMigrations (or PW API) the permission is still available as a "ghost" in the system. $permissions->has('foo') returns true. But permission is not listed in GUI or when looping through $permissions.