### PR TITLE
add isInstalled check

### DIFF
--- a/RockMigrations.module.php
+++ b/RockMigrations.module.php
@@ -3434,6 +3434,7 @@ class RockMigrations extends WireData implements Module, ConfigurableModule
    */
   public function uninstallModule($name)
   {
+    if(!$this->modules->isInstalled($name)) return;
     $this->wire->session->noMigrate = true;
     $this->modules->uninstall((string)$name);
     $this->wire->session->noMigrate = false;


### PR DESCRIPTION
only uninstall if module is installed.

to avoid Deprecated error ctype_alnum(): Argument of type bool will be interpreted as string in the future in wire/core/Modules.php:1896.

$this->modules->uninstall() method does not seem to perform that check.