### PR TITLE
fix addUser method

### DIFF
--- a/RockMigrations.module.php
+++ b/RockMigrations.module.php
@@ -1242,7 +1242,7 @@ class RockMigrations extends WireData implements Module, ConfigurableModule
   public function createUser($username, $data = [])
   {
     $user = $this->getUser($username, true);
-    if (!$user) return false;
+    if ($user) return false;
     if (!$user->id) {
       $user = $this->wire->users->add($username);
 


### PR DESCRIPTION
The getUser function returns false, if a user does not exist. Therefore the addUser method always returns false and does not create a new user.