### PR TITLE
fix: PHP Warning: Invalid argument supplied for foreach() in RockMigr…

### DIFF
--- a/RockMigrations.module.php
+++ b/RockMigrations.module.php
@@ -3506,7 +3506,7 @@ class RockMigrations extends WireData implements Module, ConfigurableModule
 
       // support setting the "additional templates" via names instead of ids
       // see https://shorturl.at/pyDRS
-      if ($key === "template_ids") {
+      if ($key === "template_ids" && $val) {
         foreach ($val as $sub => $tpl_name) {
           if (is_string($tpl_name) and $tpl_name !== '') {
             $tpl = $this->getTemplate($tpl_name);


### PR DESCRIPTION
…ations.module.php:3510

Hi, When exporting field data with getConfig(), it sometimes contains ` 'template_ids' => '',
`
This threw a Warning because the foreach cannot loop through an empty string. Also checking for $val avoids this.