### PR TITLE
Fix error message in createPage method

### DIFF
--- a/RockMigrations.module.php
+++ b/RockMigrations.module.php
@@ -1087,10 +1087,10 @@ class RockMigrations extends WireData implements Module, ConfigurableModule
     if (!$name) $name = $this->wire->pages->names()->uniquePageName();
 
     $log = "Parent $parent not found";
+    $parentName = $parent;
     $parent = $this->getPage($parent);
     if ($parent === false) {
-      $url = "https://github.com/baumrock/RockMigrations/pull/20";
-      throw new WireException("It looks like you are using an outdated syntax for createPage(), see $url");
+      $this->error("The parent '$parentName' for page $title can not be found. Did you choose the correct parent?");
     }
     if (!$parent->id) return $this->log($log);
 


### PR DESCRIPTION
This fixes the error message "It looks like you are using an outdated syntax for createPage(), see $url" if you provide a parent, but that parent can not be found, instead of saying that someone used the wrong syntax. 

I used the correct syntax, but provided a wrong name for the parent, and than the error  appeard, which is not correct..