### PR TITLE
prevent loading of secure files

### DIFF
--- a/RockMigrations.module.php
+++ b/RockMigrations.module.php
@@ -2559,6 +2559,9 @@ class RockMigrations extends WireData implements Module, ConfigurableModule
       $pagefile = $event->object;
       if ($pagefile->page->isTrash()) return;
 
+      // we can't load secure files from remote because they are not accessible
+      if ($pagefile->page->secureFiles()) return;
+
       // this makes it possible to prevent downloading at runtime
       if (!$host = $this->wire->config->filesOnDemand) return;
 


### PR DESCRIPTION
The pageFileSecure option makes PW handle serving the files only to authorized users. A basic HTTP request to a file from a page that uses this option will fail, so there is no need to even checking the existence of the file (which would also require changes as asset folders of these pages are prefixed with a dash).