### PR TITLE
make error message more verbose when parent can not be found

### DIFF
--- a/RockMigrations.module.php
+++ b/RockMigrations.module.php
@@ -3608,7 +3608,7 @@ class RockMigrations extends WireData implements Module, ConfigurableModule
       // eg 'parent_id' => '/comments'
       if ($key === "parent_id" and is_string($val) and $val !== '') {
         $parent = $this->getPage($val);
-        if (!$parent) throw new WireException("Invalid parent_id");
+        if (!$parent) throw new WireException("Invalid parent_id $val");
         $data[$key] = $parent->id;
         continue; // early exit
       }


### PR DESCRIPTION
instead of showing a generic error, show the cause of the error