### PR TITLE
add: repeater fields' data to getCode() export code

### DIFF
--- a/RockMigrations.module.php
+++ b/RockMigrations.module.php
@@ -1590,8 +1590,10 @@ class RockMigrations extends WireData implements Module, ConfigurableModule
 
       // we have a different syntax for options of an options field
       if ($item->type instanceof FieldtypeRepeater) {
-        unset($data['repeaterFields']);
+        $data['fields'] = $data['fieldContexts'];
         unset($data['fieldContexts']);
+        unset($data['repeaterFields']);
+        unset($data['template_ids']); // 'template_ids=0' prevented repeater using correct template/fieldgroup
       } elseif ($item->type instanceof FieldtypeOptions) {
         $options = [];
         foreach ($item->type->manager->getOptions($item) as $opt) {

--- a/RockMigrations.module.php
+++ b/RockMigrations.module.php
@@ -1593,7 +1593,7 @@ class RockMigrations extends WireData implements Module, ConfigurableModule
         $data['fields'] = $data['fieldContexts'];
         unset($data['fieldContexts']);
         unset($data['repeaterFields']);
-        unset($data['template_ids']); // 'template_ids=0' prevented repeater using correct template/fieldgroup
+        unset($data['template_ids']); // BUG: Exports as 'template_ids=0' that prevents repeater using correct template/fieldgroup
       } elseif ($item->type instanceof FieldtypeOptions) {
         $options = [];
         foreach ($item->type->manager->getOptions($item) as $opt) {


### PR DESCRIPTION
Adding export code for repeater fields array that is working.
`template_ids` was exporting to `0` and it was preventing it to set correct templeate/fieldgroup.