### PR TITLE
RockMigrationsConstants related fixes

### DIFF
--- a/RockMigrations.module.php
+++ b/RockMigrations.module.php
@@ -839,7 +839,7 @@ class RockMigrations extends WireData implements Module, ConfigurableModule
       $content .= "\ntrait RockMigrationsConstants\n{\n";
       foreach ($files as $file) {
         $type = $this->getConfigFileType($file, true);
-        $shortName = $this->getConfigFileName($file, true);
+        $shortName = $this->getConfigFileName($file, true, true);
         if (str_starts_with($shortName, '.')) continue;
         $longName = $this->getConfigFileName($file);
         $content .= "  const {$type}_$shortName = '$longName';\n";
@@ -1929,15 +1929,22 @@ class RockMigrations extends WireData implements Module, ConfigurableModule
    * Adds a prefix if the file is located in a module folder to avoid
    * name clashes with fields from other modules.
    *
+   * @param string $file
+   * @param bool $noPrefix if true Do not add prefix
+   * @param bool $replaceHyphens  if true Replace hyphens with underscores for valid constant names
+   *
    * Example: Returns "rockcommerce_foo" for file
    * /site/modules/RockCommerce/RockMigrations/fields/foo.php
    */
-  private function getConfigFileName(string $file, $noPrefix = false): string
+  private function getConfigFileName(string $file, $noPrefix = false, $replaceHyphens = false): string
   {
     $prefix = '';
+    $basename = basename($file);
     if (!$noPrefix) $prefix = $this->getConfigFileTag($file);
     if ($prefix) $prefix = strtolower($prefix) . "_";
-    return $prefix . str_replace('.php', '', basename($file));
+    // hyphens are not allowed in constant names
+    if ($replaceHyphens) $basename = str_replace('-', '_', $basename);
+    return $prefix . str_replace('.php', '', $basename);
   }
 
   /**

--- a/RockMigrations.module.php
+++ b/RockMigrations.module.php
@@ -104,9 +104,9 @@ class RockMigrations extends WireData implements Module, ConfigurableModule
     $this->path = $this->wire->config->paths($this);
     $this->wire->classLoader->addNamespace("RockMigrations", __DIR__ . "/classes");
 
-    // load all constant-traits in /site/modules/*/
+    // load all constant-traits in /site/modules/*/ and subfolders
     $dir = wire()->config->paths->siteModules;
-    foreach (glob($dir . '*/RockMigrationsConstants.php') as $file) {
+    foreach (glob($dir . '**/*/RockMigrationsConstants.php') as $file) {
       require_once $file;
     }
 
@@ -827,7 +827,7 @@ class RockMigrations extends WireData implements Module, ConfigurableModule
     // write constants trait for every item in $constants
     foreach ($constants as $tag => $files) {
       // built destination file path
-      $dst = wire()->config->paths->siteModules . "$tag/RockMigrationsConstants.php";
+      $dst = wire()->config->paths->siteModules . "$tag/RockMigrations/RockMigrationsConstants.php";
 
       // if file does not exist we don't create it
       if (!is_file($dst)) continue;


### PR DESCRIPTION
faba5475a008ab14415c0e35f2c5c78d2e91f0b1 fixes RockMigrationsConstants.php not being picked up and written to.

a06c6062c61b5264932a8044cf25bac0c689f8cf fixes hyphens not allowed in constant names