### PR TITLE
Add SSH and rsync port parameters to the deployment workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -96,7 +96,7 @@ jobs:
       - name: 🚚 Deploy via RSYNC and Set Permissions
         run: |
           ssh ${{ inputs.SSH_USER }}@${{ inputs.SSH_HOST }} -p${{ inputs.SSH_PORT }} "mkdir -p ${{ env.DEPLOY_FOLDER }}"
-          rsync -avz -e "ssh -p ${{ inputs.SSH_PORT }}" ${{ env.SRC }}/ ${{ inputs.SSH_USER }}@${{ inputs.SSH_HOST }}:${{ env.DEPLOY_FOLDER }}
+          rsync -avz --exclude '.git' --chmod=D755,F644 -e "ssh -p ${{ inputs.SSH_PORT }}" ${{ env.SRC }}/ ${{ inputs.SSH_USER }}@${{ inputs.SSH_HOST }}:${{ env.DEPLOY_FOLDER }}
 
       - name: 🐘 Get PHP Command
         id: get-php

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -96,7 +96,7 @@ jobs:
       - name: 🚚 Deploy via RSYNC and Set Permissions
         run: |
           ssh ${{ inputs.SSH_USER }}@${{ inputs.SSH_HOST }} -p${{ inputs.SSH_PORT }} "mkdir -p ${{ env.DEPLOY_FOLDER }}"
-          rsync -avz --exclude '.git' --chmod=D755,F644 ${{ env.SRC }}/ ${{ inputs.SSH_USER }}@${{ inputs.SSH_HOST }}:${{ env.DEPLOY_FOLDER }}
+          rsync -avz -e "ssh -p {{ inputs.SSH_PORT }}" ${{ env.SRC }}/ ${{ inputs.SSH_USER }}@${{ inputs.SSH_HOST }}:${{ env.DEPLOY_FOLDER }}
 
       - name: 🐘 Get PHP Command
         id: get-php

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -96,7 +96,7 @@ jobs:
       - name: 🚚 Deploy via RSYNC and Set Permissions
         run: |
           ssh ${{ inputs.SSH_USER }}@${{ inputs.SSH_HOST }} -p${{ inputs.SSH_PORT }} "mkdir -p ${{ env.DEPLOY_FOLDER }}"
-          rsync -avz -e "ssh -p {{ inputs.SSH_PORT }}" ${{ env.SRC }}/ ${{ inputs.SSH_USER }}@${{ inputs.SSH_HOST }}:${{ env.DEPLOY_FOLDER }}
+          rsync -avz -e "ssh -p ${{ inputs.SSH_PORT }}" ${{ env.SRC }}/ ${{ inputs.SSH_USER }}@${{ inputs.SSH_HOST }}:${{ env.DEPLOY_FOLDER }}
 
       - name: 🐘 Get PHP Command
         id: get-php

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -16,6 +16,10 @@ on:
       SSH_HOST:
         type: string
         required: true
+      SSH_PORT:
+        type: string
+        required: false
+        default: "22"  
       # by default RockMigrations will try to get the PHP version automatically
       # if this does not work for you you can set the php command manually
       # Example: PHP_COMMAND: "/user/bin/php8.1-cli"
@@ -91,14 +95,14 @@ jobs:
 
       - name: 🚚 Deploy via RSYNC and Set Permissions
         run: |
-          ssh ${{ inputs.SSH_USER }}@${{ inputs.SSH_HOST }} -p22 "mkdir -p ${{ env.DEPLOY_FOLDER }}"
+          ssh ${{ inputs.SSH_USER }}@${{ inputs.SSH_HOST }} -p${{ inputs.SSH_PORT }} "mkdir -p ${{ env.DEPLOY_FOLDER }}"
           rsync -avz --exclude '.git' --chmod=D755,F644 ${{ env.SRC }}/ ${{ inputs.SSH_USER }}@${{ inputs.SSH_HOST }}:${{ env.DEPLOY_FOLDER }}
 
       - name: 🐘 Get PHP Command
         id: get-php
         run: |
           if [ -z "${{ inputs.PHP_COMMAND }}" ]; then
-            PHP_COMMAND=$(ssh ${{ inputs.SSH_USER }}@${{ inputs.SSH_HOST }} -p22 "${{ inputs.GET_PHP_COMMAND }} ${{ env.DEPLOY_FOLDER }}/site/modules/RockMigrations/get-php.php")
+            PHP_COMMAND=$(ssh ${{ inputs.SSH_USER }}@${{ inputs.SSH_HOST }} -p${{ inputs.SSH_PORT }} "${{ inputs.GET_PHP_COMMAND }} ${{ env.DEPLOY_FOLDER }}/site/modules/RockMigrations/get-php.php")
           else
             PHP_COMMAND="${{ inputs.PHP_COMMAND }}"
           fi
@@ -107,4 +111,4 @@ jobs:
 
       - name: 🌟 Trigger RockMigrations Deployment
         run: |
-          ssh ${{ inputs.SSH_USER }}@${{ inputs.SSH_HOST }} -p22 "$PHP_COMMAND ${{ env.DEPLOY_FOLDER }}/site/modules/RockMigrations/deploy.php ${{ env.BRANCH }}"
+          ssh ${{ inputs.SSH_USER }}@${{ inputs.SSH_HOST }} -p${{ inputs.SSH_PORT }} "$PHP_COMMAND ${{ env.DEPLOY_FOLDER }}/site/modules/RockMigrations/deploy.php ${{ env.BRANCH }}"


### PR DESCRIPTION
### ✏️ Main Changes  
- Added a new workflow input:
  - `SSH_PORT`: SSH connection port (default: `22`).
- Updated the SSH connection and rsync steps to use these parameters.
- Inline documentation updated to explain how to provide these values.

### 🚀 How to Test  
1. In your fork, switch to the `RockMigrations` branch.  
2. Trigger the `deploy.yaml` workflow from the **Actions** tab in GitHub.  
3. Click **Run workflow**, adjust the `ssh_port` field, and verify that it connects successfully on non-default ports.  

### 🤔 Context  
In environments where SSH daemon use non-standard port, this enhancement makes it easier to parameterize without relying on external configurations.  