### PR TITLE
Add error handling for FieldtypeOptions migrations

### DIFF
--- a/RockMigrations.module.php
+++ b/RockMigrations.module.php
@@ -4660,7 +4660,12 @@ class RockMigrations extends WireData implements Module, ConfigurableModule
 
     $optionsArray = [];
     foreach ($options as $lang => $opt) {
+      $langName = $lang;
       $lang = $this->getLanguage($lang);
+      if (!$lang) {
+        $this->wire->warning("RockMigrations attempted to create options for '$field->name' in unconfigured language '$langName'", Notice::noGroup);
+        continue;
+      }
       $string = "";
       foreach ($opt as $k => $v) {
         if ($k === 0) $this->log("Option with key 0 skipped");


### PR DESCRIPTION
Added a polite admin warning when a FieldtypeOptions migration contains options in languages that aren't configured in ProcessWire. Currently this causes a fatal error that prevents using the admin when migrations are executed.

Example

If this migration is executed in a ProcessWire project that only has the default language and a language by the name of 'es' configured, the 'de' and 'fr' will cause an error that can't be bypassed.

```php
<?php

namespace ProcessWire;

return [
    'inputfieldClass' => 'InputfieldRadios',
    'label' => 'Image Layout',
    'optionsLang' => [
        'default' => [
            1 => 'layout_1|Layout 1',
            2 => 'layout_2|Layout 2',
            3 => 'layout_3|Layout 3',
        ],
        'es' => [
            1 => 'layout_1|Layout 1',
            2 => 'layout_2|Layout 2',
            3 => 'layout_3|Layout 3',
        ],
        'de' => [
            1 => 'layout_1|Layout 1',
            2 => 'layout_2|Layout 2',
            3 => 'layout_3|Layout 3',
        ],
        'fr' => [
            1 => 'layout_1|Layout 1',
            2 => 'layout_2|Layout 2',
            3 => 'layout_3|Layout 3',
        ],
    ],
    'type' => 'FieldtypeOptions',

    // ...etc.
];
```