### PR TITLE
fix: defer field save when a fieldtype lazy-loads as the FieldtypeText fallback (PW #2261)

### DIFF
--- a/RockMigrations.module.php
+++ b/RockMigrations.module.php
@@ -4507,7 +4507,7 @@ class RockMigrations extends WireData implements Module, ConfigurableModule
    * @param Field|string $field
    * @param array $data
    * @param Template|string $template
-   * @return void
+   * @return Field|null
    */
   public function setFieldData($field, $data, $template = null)
   {
@@ -4517,6 +4517,14 @@ class RockMigrations extends WireData implements Module, ConfigurableModule
     // Support shortcut syntax
     // $rm->setFieldData('title', 'textLanguage');
     if (is_string($data)) $data = ['type' => $data];
+
+    // Guard against persisting a field that ProcessWire lazy-loaded as the
+    // FieldtypeText fallback because its real Fieldtype module was momentarily
+    // unresolvable (e.g. right after a core update relocated the module and the
+    // module cache was still cold - see processwire-issues #2261). Saving here
+    // would overwrite the real type in the database; defer instead - it
+    // self-heals on the next refresh once the module cache is warm.
+    if ($this->shouldDeferFieldSave($field, $data)) return $field;
 
     // check if the field type has changed
     if (array_key_exists('type', $data)) {
@@ -4659,6 +4667,99 @@ class RockMigrations extends WireData implements Module, ConfigurableModule
     $field->save();
 
     return $field;
+  }
+
+  /**
+   * Should this field save be deferred because PW lazy-loaded it as the
+   * FieldtypeText fallback?
+   *
+   * When a field's real Fieldtype module cannot be resolved at load time (e.g.
+   * a transient cold module cache right after a core update relocated the
+   * module - processwire-issues #2261), ProcessWire silently substitutes
+   * FieldtypeText in Fields::makeItem(). Persisting that object would overwrite
+   * the field's real type in the database. We detect this exact situation and
+   * defer the save; it self-heals on the next refresh once the cache is warm.
+   *
+   * Inheritance-safe by design: clause 1 uses EXACT class identity, because
+   * FieldtypeTextLanguage, FieldtypeTextarea, FieldtypeEmail, FieldtypeURL,
+   * FieldtypePageTitle ... all extend FieldtypeText and would be wrongly
+   * matched by instanceof/wireInstanceOf.
+   *
+   * @param Field $field
+   * @param array $data Migration data being applied (its 'type', if any, is the intent)
+   * @return bool True if the save should be skipped this run
+   */
+  protected function shouldDeferFieldSave(Field $field, array $data): bool
+  {
+    $type = $field->type;
+
+    // 1) Effective type must be the EXACT FieldtypeText fallback sentinel.
+    if (!$type instanceof Fieldtype) return false;
+    if ($type->className() !== 'FieldtypeText') return false;
+
+    // A deliberate change to (or re-save of) FieldtypeText is never a fallback;
+    // short-circuit before the DB lookup.
+    $declared = array_key_exists('type', $data) ? $this->canonicalFieldtypeName($data['type']) : '';
+    if ($declared === 'FieldtypeText') return false;
+
+    // Intended (real) type: the declared type when it resolves to an installed
+    // module, otherwise what the DB still records for this field. This stops a
+    // mistyped/uninstalled declaration from silently disabling the guard.
+    $stored   = $this->storedFieldtypeName($field);
+    $intended = ($declared !== '' && $this->modules->isInstalled($declared)) ? $declared : $stored;
+
+    // 2) Nothing to protect if the field is genuinely (or already) FieldtypeText.
+    if ($intended === '' || $intended === 'FieldtypeText') return false;
+    if ($stored === 'FieldtypeText') return false;
+
+    // 3) Real fieldtype still installed -> transient cache miss, not a real uninstall.
+    if (!$this->modules->isInstalled($intended)) return false;
+
+    $this->log(
+      "Deferred save of field '{$field->name}': it lazy-loaded as the FieldtypeText "
+      . "fallback while its real type '{$intended}' was momentarily unresolvable. "
+      . "Skipping this run to protect the stored type; it self-heals on the next refresh."
+    );
+    return true;
+  }
+
+  /**
+   * Normalize a fieldtype declaration (Fieldtype instance, FQCN, or short alias
+   * like 'text'/'textLanguage') to its bare ProcessWire module class name.
+   *
+   * @param Fieldtype|string $type
+   * @return string e.g. 'FieldtypeText' ('' if it cannot be derived)
+   */
+  protected function canonicalFieldtypeName($type): string
+  {
+    if ($type instanceof Fieldtype) return $type->className();
+    if (!is_string($type) || $type === '') return '';
+    $type = trim(wireClassName($type, false));
+    // Mirror core Fields::getFieldtype() canonicalization so aliases and
+    // mixed-case input ('text', 'fieldtypeText', ...) map to the real class.
+    if (strpos($type, 'Fieldtype') !== 0) {
+      $type = str_ireplace('fieldtype', '', $type);
+      $type = 'Fieldtype' . ucfirst($type);
+    }
+    return $type;
+  }
+
+  /**
+   * The fieldtype class name currently stored in the database for this field.
+   *
+   * @param Field $field
+   * @return string '' for a new/unsaved field
+   */
+  protected function storedFieldtypeName(Field $field): string
+  {
+    if (!$field->id) return '';
+    $table = $this->fields->getTable();
+    $query = $this->wire->database->prepare("SELECT `type` FROM `$table` WHERE `id`=:id");
+    $query->bindValue(':id', (int) $field->id, \PDO::PARAM_INT);
+    $query->execute();
+    $type = (string) $query->fetchColumn();
+    $query->closeCursor();
+    return $this->canonicalFieldtypeName($type);
   }
 
   /**


### PR DESCRIPTION
## Summary

Updating the ProcessWire core can permanently corrupt a field's type in the
database when RockMigrations runs during the post-update module refresh: the
field's `type` flips to `FieldtypeText` and never recovers, which in the
fieldset case eventually 500s the admin. This PR adds a small guard in
`setFieldData()` that detects the transient cause and **defers** the save (skips
+ logs) so the stored type is preserved and self-heals on the next refresh.

## The symptom

After a core update, a closer field such as `tab1_END` has its
`fields.type` changed from `FieldtypeFieldsetClose` to `FieldtypeText` in the
database. From then on, every request the matching open field's core
`FieldtypeFieldsetOpen::savedField()` hook sees a wrongly-typed closer, tries to
recreate it, and throws:

```
WireException: Field may not be named 'tab1_END' because it is already used by
another field (176: tab1_END)
```

→ a permanent admin 500. The frontend stays up; reloading the admin once
sometimes "fixes" it (that reload warms the cache); hiding `site/RockMigrations`
avoids it entirely (no save runs).

## Root cause

This is upstream **[processwire-issues #2261][1]**. PW **dev 3.0.264** relocated
`FieldtypeFieldsetOpen/Close/TabOpen` from top-level `wire/modules/Fieldtype/*.module`
into the new `wire/modules/Fieldtype/FieldtypeFieldsetOpen/` subdirectory. Right
after the `wire/` swap the DB-backed module cache still points at the old paths,
so `FieldtypeFieldsetClose` is briefly unresolvable. With lazy field loading on,
`Fields::makeItem()` silently substitutes **`FieldtypeText`** for the
unresolvable type on the in-memory `Field` object.

Ryan closed #2261 as benign — and for a **normal install it is**: PW just logs a
cosmetic "Fieldtype module … is missing" warning, *nothing saves the affected
fields*, and SystemUpdater resets the module cache on the next request, so the
warning disappears.

## Why this bites RockMigrations specifically

RockMigrations **binds migration execution to module refreshes** — it hooks
`Modules::refresh` (after) and, inside that same cold-cache window,
programmatically **saves** fields: `setFieldData()` ends in an unconditional
`$field->save()`. So a field that lazy-loaded as the `FieldtypeText` fallback
gets **persisted** with the wrong type. That turns Ryan's transient, cosmetic
warning into **permanent on-disk corruption** — the closer's real type is gone
from the database, and the admin 500 above becomes permanent rather than
self-healing.

In short: the "save fields during refresh" design is the amplifier. The fix
makes that save robust against the transient fallback, without changing the
refresh-driven migration model.

## The fix

`setFieldData()` now early-returns via a new `shouldDeferFieldSave()` guard,
which **defers the save** (skip + `log()` + let it self-heal next refresh) only
when **all** of these hold:

1. the field's effective type is **exactly** `FieldtypeText` — exact
   `className()` identity, deliberately **not** `instanceof`, because
   `FieldtypeTextLanguage / Textarea / Email / URL / PageTitle / …` all extend
   `FieldtypeText` and would be wrongly matched;
2. the **intended** type — the declared `$data['type']` when it canonicalizes to
   an installed module, otherwise the DB-stored type — is *not* `FieldtypeText`;
3. that intended Fieldtype module is **still installed** (a transient cache
   miss, not a genuine uninstall).

Two small helpers support it: `canonicalFieldtypeName()` (mirrors core's
`Fields::getFieldtype()` alias/case normalization so `'text'`, `'fieldtypeText'`,
FQCNs etc. resolve identically) and `storedFieldtypeName()` (reads the field's
current `type` straight from the DB). The docblock `@return` on `setFieldData()`
is corrected from `void` to `Field|null` to match its actual returns.

The guard is generic and install-agnostic: it protects against *any*
momentarily-unresolvable fieldtype, not just the 3.0.264 module move.

## Scope (what this does and does not do)

This guard prevents the **persistent database corruption** — the data-loss part.
It deliberately does **not** try to suppress the transient cold-request
`FieldtypeFieldsetOpen` `WireException` itself; that throw is core-side and
already self-healing per #2261 (the DB stays clean, so it heals on the next warm
refresh). Keeping the scope to "don't persist the fallback" is intentional.

## Tests

A standalone, **non-destructive** harness is attached as a gist:

**https://gist.github.com/gebeer/0617b197aa1d434dc899e59106210fce**

It bootstraps a real PW instance and exercises the guard end-to-end on throwaway
`zzrmtest_*` fields (removed in a shutdown handler), instrumenting
`Fields::save` to show the exact save that would write the corruption. 18 checks
across 7 cases:

- **A** — a degraded `FieldtypeFieldsetClose` field is *not* persisted as
  `FieldtypeText` (the core corruption case);
- **B** — a *deliberate* `FieldtypeTextLanguage → FieldtypeText` migration is
  still allowed (must not regress);
- **C** — saving an open fieldset whose closer is degraded throws the production
  `WireException` but does **not** persist corruption (proves the 500 is a
  symptom, not a second writer);
- **D** — `canonicalFieldtypeName()` normalization (alias / case / FQCN, ×7);
- **E** — the `FieldtypeText` subclass family (`Email`, `URL`, `Textarea`) is
  *not* falsely deferred;
- **F** — a mistyped/uninstalled declared type falls back to the stored type and
  still defers (no false negative);
- **G** — recovery: an already-`FieldtypeText` field re-declared to another real
  fieldtype heals normally.

RockMigrations doesn't have a tests directory today, so I've left this as a gist
rather than dropping a full-bootstrap script into the repo — happy to adapt it
into whatever shape you'd want for a seed regression test.

## Note on the inline comments

I've left fairly **extensive inline comments** on the guard on purpose: the
failure mode is subtle and the code is easy to "simplify" straight back into the
bug — e.g. swapping the exact `className()` check for `instanceof`, or letting a
declared type win unconditionally. The comments are there for the next reader,
not load-bearing — **feel free to trim them to taste.**

## References

- ProcessWire issue: https://github.com/processwire/processwire-issues/issues/2261
- Test harness gist: https://gist.github.com/gebeer/0617b197aa1d434dc899e59106210fce

[1]: https://github.com/processwire/processwire-issues/issues/2261
